### PR TITLE
Add DiT-PT for paired image-to-image translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ To launch DiT-XL/2 (256x256) training with `1` GPUs on one node:
 accelerate launch --mixed_precision fp16 train.py --model DiT-XL/2 --feature-path /path/to/store/features
 ```
 
+## Paired Image-to-Image with DiT-PT
+
+This fork adds a simple two-stream token conditioning setup for paired image translation. Prepare your paired dataset and then run:
+
+```bash
+python train.py --task i2i_dit_pt --model DiT-XL/2 \
+  --paired_root data/paired_af_he --image-size 256 --train_steps 1000
+```
+
+To sample from a trained checkpoint:
+
+```bash
+python scripts/sample_i2i.py --ckpt path/to/ckpt.pt --src path/to/src.png --image-size 256
+```
+
 To launch DiT-XL/2 (256x256) training with `N` GPUs on one node:
 ```bash
 accelerate launch --multi_gpu --num_processes N --mixed_precision fp16 train.py --model DiT-XL/2 --feature-path /path/to/store/features

--- a/configs/i2i_dit_pt.yaml
+++ b/configs/i2i_dit_pt.yaml
@@ -1,0 +1,15 @@
+task: i2i_dit_pt
+image_size: 256
+vae: sd_vae
+train_steps: 300000
+optimizer: adamw
+lr: 2.0e-4
+batch_size: 64
+time_on: both
+direction_token: true
+lambda_deltaE: 0.05
+lambda_ssim: 0.05
+paired_root: data/paired_af_he/
+vae_cache_dir: cache/latents_af_he/
+sampler: dpm_solver
+sample_steps: 20

--- a/datasets/paired_i2i.py
+++ b/datasets/paired_i2i.py
@@ -1,0 +1,86 @@
+import os
+import csv
+from typing import Optional, Dict
+
+from PIL import Image
+import torch
+from torch.utils.data import Dataset
+from torchvision import transforms
+import numpy as np
+
+
+class PairedI2I(Dataset):
+    """Dataset returning paired source/target images for I2I translation."""
+
+    def __init__(self, root: str, split_csv: str = "split.csv", size: int = 256,
+                 augment: bool = True, vae_cache_dir: Optional[str] = None):
+        self.root = root
+        self.size = size
+        self.augment = augment
+        self.vae_cache_dir = vae_cache_dir
+
+        csv_path = os.path.join(root, split_csv)
+        self.pairs = []
+        with open(csv_path, "r") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if len(row) >= 2:
+                    self.pairs.append((row[0], row[1]))
+
+        self.transform = transforms.Compose([
+            transforms.Resize(size, interpolation=transforms.InterpolationMode.BILINEAR),
+            transforms.CenterCrop(size),
+            transforms.ToTensor(),
+            transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+        ])
+        if augment:
+            self.augment_transform = transforms.RandomHorizontalFlip(p=0.5)
+        else:
+            self.augment_transform = lambda x: x
+
+        if self.vae_cache_dir is not None:
+            os.makedirs(self.vae_cache_dir, exist_ok=True)
+
+    def __len__(self) -> int:
+        return len(self.pairs)
+
+    def _load_image(self, rel_path: str) -> Image.Image:
+        path = os.path.join(self.root, rel_path)
+        return Image.open(path).convert("RGB")
+
+    def __getitem__(self, index: int) -> Dict[str, torch.Tensor]:
+        src_rel, tgt_rel = self.pairs[index]
+        src_img = self._load_image(src_rel)
+        tgt_img = self._load_image(tgt_rel)
+
+        src_img = self.augment_transform(src_img)
+        tgt_img = self.augment_transform(tgt_img)
+
+        src_img = self.transform(src_img)
+        tgt_img = self.transform(tgt_img)
+        sample_id = os.path.splitext(os.path.basename(src_rel))[0]
+        return {"src_img": src_img, "tgt_img": tgt_img, "id": sample_id}
+
+    # ----------------- VAE utilities -----------------
+    def encode_to_latents(self, vae, src_img: torch.Tensor, tgt_img: torch.Tensor, sample_id: str):
+        """Encode images to latents using a provided VAE.
+        Optionally cache the result to disk for faster subsequent loads."""
+        z_src = z_tgt = None
+        cache_path = None
+        if self.vae_cache_dir is not None:
+            cache_path = os.path.join(self.vae_cache_dir, f"{sample_id}.npz")
+            if os.path.exists(cache_path):
+                data = np.load(cache_path)
+                z_src = torch.from_numpy(data["z_src"])  # type: ignore[arg-type]
+                z_tgt = torch.from_numpy(data["z_tgt"])  # type: ignore[arg-type]
+        if z_src is None or z_tgt is None:
+            src_img = src_img.unsqueeze(0)
+            tgt_img = tgt_img.unsqueeze(0)
+            with torch.no_grad():
+                z_src = vae.encode(src_img).latent_dist.sample() * 0.18215
+                z_tgt = vae.encode(tgt_img).latent_dist.sample() * 0.18215
+            z_src = z_src.squeeze(0)
+            z_tgt = z_tgt.squeeze(0)
+            if cache_path is not None:
+                np.savez(cache_path, z_src=z_src.cpu().numpy(), z_tgt=z_tgt.cpu().numpy())
+        return z_src, z_tgt

--- a/losses/color.py
+++ b/losses/color.py
@@ -1,0 +1,18 @@
+import torch
+
+try:
+    from kornia.color import rgb_to_lab
+    from kornia.metrics import delta_e
+except Exception:  # pragma: no cover
+    rgb_to_lab = None
+    delta_e = None
+
+
+def deltaE2000(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Approximate DeltaE2000 color difference.
+    If kornia is not available, returns zeros to allow training to continue."""
+    if rgb_to_lab is None or delta_e is None:
+        return torch.zeros(x.size(0), device=x.device)
+    x_lab = rgb_to_lab((x + 1) / 2)
+    y_lab = rgb_to_lab((y + 1) / 2)
+    return delta_e(x_lab, y_lab, method='2000').view(x.size(0), -1).mean(dim=1)

--- a/losses/structure.py
+++ b/losses/structure.py
@@ -1,0 +1,13 @@
+import torch
+
+try:
+    import kornia
+except Exception:  # pragma: no cover
+    kornia = None
+
+
+def ssim(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Structural similarity index. Returns ones if kornia missing."""
+    if kornia is None:
+        return torch.ones(x.size(0), device=x.device)
+    return kornia.metrics.ssim(x, y, 11)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,2 @@
+from .dit import *
+from .dit import DiT_models

--- a/models/dit_pt.py
+++ b/models/dit_pt.py
@@ -1,0 +1,53 @@
+import torch
+import torch.nn as nn
+from typing import Optional
+
+
+class DiTPT(nn.Module):
+    """Wrapper adding paired token conditioning to a base DiT model."""
+
+    def __init__(self, base_dit, hidden_size: int, use_direction_token: bool = False):
+        super().__init__()
+        self.dit = base_dit
+        self.type_embed_src = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.type_embed_tgt = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        if use_direction_token:
+            self.dir_embed = nn.Embedding(8, hidden_size)
+        else:
+            self.dir_embed = None
+        nn.init.normal_(self.type_embed_src, std=0.02)
+        nn.init.normal_(self.type_embed_tgt, std=0.02)
+        if self.dir_embed is not None:
+            nn.init.normal_((self.dir_embed.weight), std=0.02)
+
+    def forward(self, z_src_clean: torch.Tensor, z_tgt_noisy: torch.Tensor,
+                t: torch.Tensor, direction_id: Optional[torch.Tensor] = None,
+                time_on: str = 'both') -> torch.Tensor:
+        """Forward pass producing epsilon prediction for target tokens."""
+        # patchify
+        src_tok = self.dit.patchify(z_src_clean)
+        tgt_tok = self.dit.patchify(z_tgt_noisy)
+
+        src_tok = src_tok + self.type_embed_src
+        tgt_tok = tgt_tok + self.type_embed_tgt
+
+        te = self.dit.t_embedder(t)
+        if time_on == 'both':
+            src_tok = src_tok + te.unsqueeze(1)
+        tgt_tok = tgt_tok + te.unsqueeze(1)
+
+        prefix = []
+        if getattr(self.dit, 'cls_token', None) is not None:
+            prefix.append(self.dit.cls_token.expand(src_tok.size(0), -1, -1))
+        if self.dir_embed is not None:
+            assert direction_id is not None, "direction_id required when using direction token"
+            prefix.append(self.dir_embed(direction_id).unsqueeze(1))
+
+        seq = torch.cat(prefix + [src_tok, tgt_tok], dim=1)
+        eps_all = self.dit.forward_tokens(seq, t)
+
+        n_prefix = sum(p.size(1) for p in prefix)
+        n_src = src_tok.size(1)
+        eps_tgt = eps_all[:, n_prefix + n_src:, :]
+        eps_tgt = self.dit.unpatchify_eps(eps_tgt, z_tgt_noisy.shape)
+        return eps_tgt

--- a/sampling_i2i.py
+++ b/sampling_i2i.py
@@ -1,0 +1,23 @@
+import torch
+from diffusion import create_diffusion
+from typing import Optional
+
+
+def i2i_sample(dit_pt, vae, src_img: torch.Tensor, steps: int = 20,
+               direction_id: Optional[torch.Tensor] = None,
+               time_on: str = 'both', scheduler: str = 'dpm_solver'):
+    """Simple i2i sampling loop."""
+    device = next(dit_pt.parameters()).device
+    diffusion = create_diffusion(str(steps))
+    with torch.no_grad():
+        if src_img.dim() == 3:
+            src_img = src_img.unsqueeze(0)
+        z_src = vae.encode(src_img).latent_dist.sample() * 0.18215
+        z = torch.randn_like(z_src)
+
+        def model_fn(x, t):
+            return dit_pt(z_src, x, t, direction_id, time_on=time_on)
+
+        samples = diffusion.p_sample_loop(model_fn, z.shape, z, progress=False, device=device)
+        imgs = vae.decode(samples / 0.18215).sample
+        return imgs

--- a/scripts/sample_i2i.py
+++ b/scripts/sample_i2i.py
@@ -1,0 +1,52 @@
+import argparse
+import torch
+from torchvision.utils import save_image
+from diffusers.models import AutoencoderKL
+
+from models import DiT_models
+from models.dit_pt import DiTPT
+from sampling_i2i import i2i_sample
+
+
+def main(args):
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    latent_size = args.image_size // 8
+    base = DiT_models[args.model](input_size=latent_size, learn_sigma=False, num_classes=1)
+    model = DiTPT(base, hidden_size=base.x_embedder.proj.out_channels,
+                  use_direction_token=args.direction_token).to(device)
+    state_dict = torch.load(args.ckpt, map_location='cpu')
+    model.load_state_dict(state_dict)
+    model.eval()
+    vae = AutoencoderKL.from_pretrained(f"stabilityai/sd-vae-ft-{args.vae}").to(device)
+
+    src_img = Image.open(args.src).convert('RGB')
+    transform = transforms.Compose([
+        transforms.Resize(args.image_size, interpolation=transforms.InterpolationMode.BILINEAR),
+        transforms.CenterCrop(args.image_size),
+        transforms.ToTensor(),
+        transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),
+    ])
+    src_tensor = transform(src_img).unsqueeze(0).to(device)
+    direction_id = torch.tensor([0], device=device) if args.direction_token else None
+    imgs = i2i_sample(model, vae, src_tensor, steps=args.steps,
+                      direction_id=direction_id, time_on=args.time_on)
+    save_image(imgs, args.out, normalize=True, value_range=(-1, 1))
+
+
+if __name__ == '__main__':
+    from torchvision import transforms
+    from PIL import Image
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', type=str, default='configs/i2i_dit_pt.yaml')
+    parser.add_argument('--ckpt', type=str, required=True)
+    parser.add_argument('--src', type=str, required=True)
+    parser.add_argument('--out', type=str, default='out.png')
+    parser.add_argument('--model', type=str, default='DiT-XL/2')
+    parser.add_argument('--image-size', type=int, default=256)
+    parser.add_argument('--vae', type=str, choices=['ema', 'sd_vae', 'mse'], default='sd_vae')
+    parser.add_argument('--steps', type=int, default=20)
+    parser.add_argument('--direction-token', action='store_true')
+    parser.add_argument('--time_on', type=str, choices=['tgt', 'both'], default='both')
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
## Summary
- add `PairedI2I` dataset with optional VAE latent caching
- introduce `DiTPT` wrapper and token-level hooks in `DiT`
- extend `train.py` with `i2i_dit_pt` task and sampling utilities

## Testing
- `python -m py_compile datasets/paired_i2i.py models/dit_pt.py sampling_i2i.py scripts/sample_i2i.py losses/color.py losses/structure.py train.py models/dit.py`
- `python - <<'PY'
import torch
from models import DiT_models
from models.dit_pt import DiTPT
from diffusion import create_diffusion

latent_size = 32
base = DiT_models['DiT-S/2'](input_size=latent_size, learn_sigma=False, num_classes=1)
model = DiTPT(base, hidden_size=base.x_embedder.proj.out_channels)
model.train()
diffusion = create_diffusion("")

B=2
z_src = torch.randn(B,4,latent_size,latent_size)
z_tgt = torch.randn(B,4,latent_size,latent_size)
t = torch.randint(0,diffusion.num_timesteps,(B,))
noise = torch.randn_like(z_tgt)
z_tgt_noisy = diffusion.q_sample(z_tgt,t,noise)
out = model(z_src,z_tgt_noisy,t,None)
loss = torch.nn.functional.mse_loss(out,noise)
loss.backward()
print('ok', out.shape)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b8454d11948332bd704861a77a2997