### PR TITLE
Add PyTorch Lightning training pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ To launch DiT-XL/2 (256x256) training with `1` GPUs on one node:
 accelerate launch --mixed_precision fp16 train.py --model DiT-XL/2 --feature-path /path/to/store/features
 ```
 
+### Lightning Training
+
+For richer logging and easier experiment management, a PyTorch Lightning
+training entry point is available in [`train_lightning.py`](train_lightning.py).
+It uses a YAML config to control hyperparameters and learning rate
+scheduling and logs metrics such as loss and learning rate to TensorBoard.
+
+```bash
+python train_lightning.py --config configs/lightning.yaml
+```
+
 ## Paired Image-to-Image with DiT-PT
 
 This fork adds a simple two-stream token conditioning setup for paired image translation. Prepare your paired dataset and then run:

--- a/configs/lightning.yaml
+++ b/configs/lightning.yaml
@@ -1,0 +1,17 @@
+feature_path: features
+results_dir: lightning_logs
+model: DiT-S/8
+image_size: 256
+num_classes: 1000
+batch_size: 32
+max_epochs: 1
+num_workers: 4
+vae: ema
+learning_type: diffusion-transformer
+optimizer:
+  lr: 1.0e-4
+scheduler:
+  name: cosine
+  T_max: 1000
+  eta_min: 1.0e-6
+

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,5 @@ dependencies:
     - diffusers
     - accelerate
     - tqdm
+    - pytorch-lightning
+    - tensorboard

--- a/train_lightning.py
+++ b/train_lightning.py
@@ -1,0 +1,135 @@
+"""PyTorch Lightning training script for DiT.
+
+This script wraps the existing DiT training logic into a LightningModule
+so that we get richer logging, TensorBoard support and configurable
+learning rate schedulers via a YAML config file.
+"""
+
+import argparse
+from copy import deepcopy
+import os
+import yaml
+
+import torch
+from torch.utils.data import DataLoader
+
+import pytorch_lightning as pl
+from pytorch_lightning.loggers import TensorBoardLogger
+from pytorch_lightning.callbacks import LearningRateMonitor
+
+from models import DiT_models
+from diffusion import create_diffusion
+from diffusers.models import AutoencoderKL
+
+# Reuse utility functions and dataset from the original training script
+from train import CustomDataset, update_ema, requires_grad
+
+
+class DiTLightningModule(pl.LightningModule):
+    """LightningModule encapsulating a DiT model and diffusion training."""
+
+    def __init__(self, cfg):
+        super().__init__()
+        self.save_hyperparameters(cfg)
+
+        latent_size = cfg["image_size"] // 8
+        self.model = DiT_models[cfg["model"]](
+            input_size=latent_size, num_classes=cfg.get("num_classes", 1000)
+        )
+        self.diffusion = create_diffusion(timestep_respacing="")
+        self.vae = AutoencoderKL.from_pretrained(
+            f"stabilityai/sd-vae-ft-{cfg.get('vae', 'ema')}"
+        )
+
+        # Expose the training type for logging purposes
+        self.learning_type = cfg.get("learning_type", "diffusion-transformer")
+
+        # Exponential moving average of model weights
+        self.ema = deepcopy(self.model)
+        requires_grad(self.ema, False)
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.AdamW(self.parameters(), lr=self.hparams["optimizer"]["lr"])
+        sched_cfg = self.hparams.get("scheduler")
+        if sched_cfg:
+            name = sched_cfg.get("name", "").lower()
+            if name == "cosine":
+                scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+                    optimizer,
+                    T_max=sched_cfg.get("T_max", self.trainer.max_epochs),
+                    eta_min=sched_cfg.get("eta_min", 0.0),
+                )
+                return {"optimizer": optimizer, "lr_scheduler": scheduler}
+            if name == "step":
+                scheduler = torch.optim.lr_scheduler.StepLR(
+                    optimizer,
+                    step_size=sched_cfg.get("step_size", 1),
+                    gamma=sched_cfg.get("gamma", 0.1),
+                )
+                return {"optimizer": optimizer, "lr_scheduler": scheduler}
+        return optimizer
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        t = torch.randint(0, self.diffusion.num_timesteps, (x.shape[0],), device=self.device)
+        model_kwargs = dict(y=y)
+        loss_dict = self.diffusion.training_losses(self.model, x, t, model_kwargs)
+        loss = loss_dict["loss"].mean()
+
+        for k, v in loss_dict.items():
+            self.log(k, v.mean(), on_step=True, prog_bar=(k == "loss"))
+        # Log current learning rate
+        lr = self.trainer.optimizers[0].param_groups[0]["lr"]
+        self.log("lr", lr, on_step=True, prog_bar=True)
+        return loss
+
+    def on_train_batch_end(self, outputs, batch, batch_idx):
+        # Update EMA weights after each optimization step
+        update_ema(self.ema, self.model)
+
+    def on_train_start(self):
+        # Record the learning type in TensorBoard for experiment tracking
+        if isinstance(self.logger, TensorBoardLogger):
+            self.logger.experiment.add_text("learning/type", self.learning_type)
+
+
+def load_config(path):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def main(cfg_path):
+    cfg = load_config(cfg_path)
+
+    features_dir = os.path.join(cfg["feature_path"], "imagenet256_features")
+    labels_dir = os.path.join(cfg["feature_path"], "imagenet256_labels")
+    dataset = CustomDataset(features_dir, labels_dir)
+
+    loader = DataLoader(
+        dataset,
+        batch_size=cfg["batch_size"],
+        shuffle=True,
+        num_workers=cfg.get("num_workers", 4),
+        pin_memory=True,
+        drop_last=True,
+    )
+
+    model = DiTLightningModule(cfg)
+    logger = TensorBoardLogger(save_dir=cfg["results_dir"], name="dit")
+    lr_monitor = LearningRateMonitor(logging_interval="step")
+
+    trainer = pl.Trainer(
+        max_epochs=cfg["max_epochs"],
+        logger=logger,
+        callbacks=[lr_monitor],
+        log_every_n_steps=cfg.get("log_every", 50),
+    )
+    trainer.fit(model, loader)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train DiT with PyTorch Lightning")
+    parser.add_argument("--config", type=str, required=True, help="Path to YAML config file")
+    args = parser.parse_args()
+    main(args.config)
+


### PR DESCRIPTION
## Summary
- Introduce `train_lightning.py` with a LightningModule for DiT, logging metrics and learning rate
- Provide `configs/lightning.yaml` to configure hyperparameters and adaptive LR scheduling
- Include PyTorch Lightning and TensorBoard dependencies and document new training option in README

## Testing
- `python -m py_compile train_lightning.py`


------
https://chatgpt.com/codex/tasks/task_e_68b94706865083328514f4d5374969a9